### PR TITLE
Fix botton-left corner of Bern symbol

### DIFF
--- a/symbols/13x13/be.svg
+++ b/symbols/13x13/be.svg
@@ -1,1 +1,1 @@
-<svg width="13" height="13" xmlns="http://www.w3.org/2000/svg"><path fill="#BF4A3A" d="M0 0v12.9l13 .1V0z"/><path fill="#FFD800" d="M1 1v6l5 5h6V6L7 1z"/><path fill="#333333" d="M2 2v2h2v2H2v1h3v2h1V7h1v3h1V9h2v2h1V7L7 3H6V2z"/></svg>
+<svg width="13" height="13" xmlns="http://www.w3.org/2000/svg"><path fill="#BF4A3A" d="M0 0v13h13V0z"/><path fill="#FFD800" d="M1 1v6l5 5h6V6L7 1z"/><path fill="#333333" d="M2 2v2h2v2H2v1h3v2h1V7h1v3h1V9h2v2h1V7L7 3H6V2z"/></svg>


### PR DESCRIPTION
There was a 0.1 pixel gap before.